### PR TITLE
ユーザーマイページのトップ画面の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,3 +7,4 @@
 @import "modules/userfooter";
 @import "modules/mainheader";
 @import "modules/mainfooter";
+@import "modules/mypage";

--- a/app/assets/stylesheets/modules/_mypage.scss
+++ b/app/assets/stylesheets/modules/_mypage.scss
@@ -1,0 +1,220 @@
+// Place all the styles related to the users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/
+
+
+* {
+  box-sizing: border-box;
+}
+
+
+//ここから、ユーザーメニューバー画面（=users/menu.html）の装飾
+
+.Single-Container {
+  background-color: #f5f5f5;
+}
+
+//ヘッダー部分のクラス名は「%header.MenuHeader」とする（内容はtopページヘッダーと同じ）
+.MenuHeader {    //topページヘッダー部分の装飾（クラス名は「MenuHeader」）
+  padding: 0 60px;
+
+  //「.MenuHeader」以下のクラスは、部分テンプレートのscssにて指定
+}
+
+//コンテンツ表示部分のクラス名は「%main.l-container.clearfix」とする
+.L-Container {
+  margin: 40px auto 0;
+  width: 700px;
+  padding: 0 0 40px;
+  display: block;
+
+  .L-Content {
+    float: none;
+    width: 700px;
+    background-color: #3CCACE;
+    border-radius: 4px;
+    margin-bottom: 40px;    //トップアイコンとメニュー見出しの間
+
+    .MypageUserIcon {
+      height: 200px;
+      position: relative;
+      padding: 20px;
+      background: url(/jp/assets/img/mypage/user-bg.jpg?25704017);
+      background-repeat: no-repeat;
+      background-size: cover;
+      text-align: center;
+
+      a {
+        display: block;
+        position: absolute;
+        top: 50%;
+        left: 0;
+        right: 0;
+        transform: translate(0, -50%);
+        color: #333;
+        text-decoration: none;
+      }
+
+      figure {
+        overflow: hidden;
+        width: 60px;
+        height: 60px;
+        margin: 0 auto;
+        border-radius: 50%;
+
+        fieldset, img {
+          border: 0;
+          width: 100%;
+          vertical-align: bottom;
+        }
+      }
+
+      .bold {
+        margin: 8px 0 0;
+        font-size: 14px;
+        font-weight: 600;
+        line-height: 1.4;
+      }
+
+      .MypageNumber {
+        div {
+          display: inline-block;
+          font-size: 14px;
+
+          +div {
+            margin: 0 0 0 16px;
+          }
+        }
+
+        span {
+          margin: 0 0 0 8px;
+          font-size: 16px;
+        }
+      }
+    }
+  }
+
+
+  .L-Side {
+      float: none;
+
+    .MypageNav {
+      display: flex;    //メニューバーを左右2列に並べる
+
+      .NavLeft {    //メニューバー第1列
+        margin-right: 70px;
+
+        ul.MypageNavList {
+          margin: 16px 0;
+
+          li {
+            border-top: 1px solid #eee;
+            width: 315px;    //メニューボタンの表示幅
+
+            .MypageNavListItem {
+              position: relative;
+              display: block;
+              min-height: 48px;
+              padding: 16px;
+              background: #fff;
+              font-size: 14px;
+              color: #333;
+              text-decoration: none;
+
+              .icon-arrow-right {
+                position: absolute;
+                top: 20px;
+                right: 16px;
+                display: inline-block;
+                width: 8px;
+                height: 8px;
+                border-top: solid 2px #ccc;
+                border-right: solid 2px #ccc;
+                -webkit-transform: rotate(45deg);
+                transform: rotate(45deg);
+              }
+
+              span.MypageNavNumber {
+                position: absolute;
+                top: 50%;
+                right: 210px;
+                width: 24px;
+                height: 24px;
+                border-radius: 50%;
+                background: #ea352d;
+                text-align: center;
+                line-height: 24px;
+                color: #fff;
+                transform: translate(0, -50%);
+              }
+            }
+          }
+          li:first-child {
+            border-top: 0px;
+          }
+
+        }
+
+        .MypageNavHead {
+          font-size: 16px;
+          font-weight: bold;
+        }
+      }
+
+      .NavRight {    //メニューバー第1列
+        ul.MypageNavList {
+          margin: 16px 0 66px 0;
+
+          li {
+            border-top: 1px solid #eee;
+            width: 315px;    //メニューボタンの表示幅
+
+            .MypageNavListItem {
+              position: relative;
+              display: block;
+              min-height: 48px;
+              padding: 16px;
+              background: #fff;
+              font-size: 14px;
+              color: #333;
+              text-decoration: none;
+
+              .icon-arrow-right {
+                position: absolute;
+                top: 20px;
+                right: 16px;
+                display: inline-block;
+                width: 8px;
+                height: 8px;
+                border-top: solid 2px #ccc;
+                border-right: solid 2px #ccc;
+                -webkit-transform: rotate(45deg);
+                transform: rotate(45deg);
+              }
+            }
+          }
+          li:first-child {
+            border-top: 0px;
+          }
+        }
+
+        .MypageNavHead {
+          font-size: 16px;
+          font-weight: bold;
+        }
+      }
+    }
+  }
+}
+
+//フッター部分のクラス名は「%footer.MenuFooter」とする（内容はtopページフッターと同じ）
+.MenuFooter {    //バナー+フッター部分の装飾（親クラス「MenuFooter」で括った）
+  //「.MenuFooter」以下のクラスは、部分テンプレートのscssにて指定
+}
+
+//出品ボタン部分のクラス名は「.MenuPurchaseBtn」とする（内容はtopページ出品ボタンと同じ）
+.MenuPurchaseBtn {
+  //「.MenuPurchaseBtn」以下のクラスは、部分テンプレートのscssにて指定
+}
+
+

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,0 +1,6 @@
+class MypagesController < ApplicationController
+
+  def index
+  end
+
+end

--- a/app/views/mypages/index.html.haml
+++ b/app/views/mypages/index.html.haml
@@ -1,0 +1,155 @@
+-#ユーザーマイページTop画面
+
+!!!
+-#   %body
+
+.Single-Container
+  %header.MenuHeader
+
+    -#Header部分（部分テンプレートで参照）
+    -# = render partial: "/layouts/main-header-login"
+    = render partial: "/layouts/main-header"
+
+
+  -#コンテンツ部分
+  %main.L-Container.clearfix
+
+    .L-Content
+      %section.MypageUserIcon
+        %a{href: "/"}
+          %figure
+            %img{alt: "", height: "60", src: "//static.mercdn.net/images/member_photo_noimage_thumb.png", width: "60"}/
+          %h2.bold Gudetama
+          .MypageNumber
+            %div
+              評価
+              %span.bold 1234
+            %div
+              出品数
+              %span.bold 567
+
+    -#メニューバー部分
+    .L-Side
+      %nav.MypageNav
+
+        -#メニューバー第1列（バーのレイアウトは左右2列）
+        .NavLeft
+
+          -#見出し表示
+          %h3.MypageNavHead マイページメニュー
+          %ul.MypageNavList
+            %li
+              = link_to "#", class: "MypageNavListItem" do
+                お知らせ
+                %span.MypageNavNumber
+                  12
+                %i.icon-arrow-right
+            %li
+              = link_to "#", class: "MypageNavListItem" do
+                やることリスト
+                %i.icon-arrow-right
+            %li
+              = link_to "#", class: "MypageNavListItem" do
+                いいね！一覧
+                %i.icon-arrow-right
+            %li
+              = link_to "#", class: "MypageNavListItem" do
+                出品する
+                %i.icon-arrow-right
+            %li
+              = link_to "#", class: "MypageNavListItem" do
+                下書き一覧
+                %i.icon-arrow-right
+            %li
+              = link_to "#", class: "MypageNavListItem" do
+                出品した商品 - 出品中
+                %i.icon-arrow-right
+            %li
+              = link_to "#", class: "MypageNavListItem" do
+                出品した商品 - 取引中
+                %i.icon-arrow-right
+            %li
+              = link_to "#", class: "MypageNavListItem" do
+                出品した商品 - 売却済み
+                %i.icon-arrow-right
+            %li
+              = link_to "#", class: "MypageNavListItem" do
+                購入した商品 - 取引中
+                %i.icon-arrow-right
+            %li
+              = link_to "#", class: "MypageNavListItem" do
+                購入した商品 - 過去の取引
+                %i.icon-arrow-right
+            %li
+              = link_to "#", class: "MypageNavListItem" do
+                ニュース一覧
+                %i.icon-arrow-right
+            %li
+              = link_to "#", class: "MypageNavListItem" do
+                評価一覧
+                %i.icon-arrow-right
+            %li
+              = link_to "#", class: "MypageNavListItem" do
+                ガイド
+                %i.icon-arrow-right
+            %li
+              = link_to "#", class: "MypageNavListItem" do
+                お問い合わせ
+                %i.icon-arrow-right
+
+        -#メニューバー第2列
+        .NavRight
+
+          -#見出し表示
+          %h3.MypageNavHead メルペイ
+          %ul.MypageNavList
+            %li
+              = link_to "#", class: "MypageNavListItem" do
+                売上・振込申請
+                %i.icon-arrow-right
+            %li
+              = link_to "#", class: "MypageNavListItem" do
+                ポイント
+                %i.icon-arrow-right
+
+          -#見出し表示
+          %h3.MypageNavHead 設定
+          %ul.MypageNavList
+            %li
+              = link_to "#", class: "MypageNavListItem" do
+                プロフィール
+                %i.icon-arrow-right
+            %li
+              = link_to "#", class: "MypageNavListItem" do
+                発送元・お届け先住所変更
+                %i.icon-arrow-right
+            %li
+              = link_to "#", class: "MypageNavListItem" do
+                支払い方法
+                %i.icon-arrow-right
+            %li
+              = link_to "#", class: "MypageNavListItem" do
+                メール/パスワード
+                %i.icon-arrow-right
+            %li
+              = link_to "#", class: "MypageNavListItem" do
+                本人情報
+                %i.icon-arrow-right
+            %li
+              = link_to "#", class: "MypageNavListItem" do
+                電話番号の確認
+                %i.icon-arrow-right
+            %li
+              = link_to "#", class: "MypageNavListItem" do
+                ログアウト
+                %i.icon-arrow-right
+
+  %footer.MenuFooter
+    -#Banner部分+Footer部分（部分テンプレートで参照）
+    = render partial: "/layouts/main-footer"
+
+  .MenuPurchaseBtn
+    -#右下の「出品する」ボタン（部分テンプレートで参照）
+    = render partial: "/layouts/purchasebtn"
+
+

--- a/app/views/mypages/index.html.haml
+++ b/app/views/mypages/index.html.haml
@@ -16,9 +16,9 @@
 
     .L-Content
       %section.MypageUserIcon
-        %a{href: "/"}
+        = link_to "/" do
           %figure
-            %img{alt: "", height: "60", src: "//static.mercdn.net/images/member_photo_noimage_thumb.png", width: "60"}/
+            = image_tag "//static.mercdn.net/images/member_photo_noimage_thumb.png"
           %h2.bold Gudetama
           .MypageNumber
             %div

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,19 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
     registrations: 'users/registrations',
-}
+  }
+
   devise_scope :user do
     get 'addresses', to: 'users/registrations#new_address'
     post 'addresses', to: 'users/registrations#create_address'
   end
+
   root 'items#index'
+
+  resources :mypages do
+    collection do
+      get 'index'
+    end
+  end
 
 end


### PR DESCRIPTION
# What
フリマアプリのユーザーマイページ画面につき、そのトップ画面のマークアップ。
この画面から各機能の画面に遷移させる想定のため、メニューボタンが並んだ画面とする。
その他、ログインしたユーザーの簡易なアカウント情報を表示する。

# Why
開発するフリマアプリにて必要となるビューの実装。
ユーザーマイページの各機能に遷移する入口となる画面を作成するもの。

# ブラウザ表示画像
https://gyazo.com/94245d1ee063a1c690b9baa361afc2d6
