### PR TITLE
ユーザーログアウト画面の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,3 +9,4 @@
 @import "modules/mainfooter";
 @import "modules/mypage";
 @import "modules/creditcard";
+@import "modules/log-out";

--- a/app/assets/stylesheets/modules/_log-out.scss
+++ b/app/assets/stylesheets/modules/_log-out.scss
@@ -1,0 +1,86 @@
+// Place all the styles related to the users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/
+
+
+* {
+  box-sizing: border-box;
+}
+
+.Single-Container {
+  background-color: #f5f5f5;
+}
+
+//ログアウト画面（=mypages/logout.html）の装飾
+
+//ヘッダー部分のクラス名は「%header.LogoutHeader」とする（内容はtopページヘッダーと同じ）
+.LogoutHeader {    //topページヘッダー部分の装飾（クラス名は「LogoutHeader」）
+  padding: 0 60px;
+  //LogoutHeaderクラス以下のトップページヘッダー部分は、部分template「mainheader.scss」で記述
+}
+
+
+//コンテンツ表示部分のクラス名は「%main.l-container.clearfix」とする
+.L-Container {
+    margin: 40px auto 0;
+    width: 700px;
+    padding: 0 0 40px;
+    display: block;
+
+  .L-Content {
+      float: none;
+      width: 700px;
+  }
+
+  .L-Chapter-Container:first-child {
+    margin: 0;
+  }
+
+  .L-Chapter-Container {
+    margin: 40px 0 0;
+    background: #fff;
+  }
+
+  .L-Single-Inner {
+      padding: 64px;
+      border-top: 1px solid #f5f5f5;
+  }
+
+  .L-Single-Content {
+    max-width: 320px;
+    margin: 0 auto;
+  }
+}
+
+
+.Btn-Default {
+  display: block;
+  width: 100%;
+  line-height: 48px;
+  font-size: 14px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  -webkit-transition: all ease-out .3s;
+  transition: all ease-out .3s;
+  cursor: pointer;
+  text-align: center;
+}
+button {
+  min-height: 1.5em;
+  border: 0;
+  outline: 0;
+  cursor: pointer;
+}
+
+
+//フッター部分のクラス名は「%footer.LogoutFooter」とする（内容はtopページフッターと同じ）
+.LogoutFooter {    //バナー+フッター部分の装飾（親クラス「LogoutFooter」で括った）
+  //LogoutFooterクラス以下のトップページフッター部分は、部分template「mainfooter.scss」で記述
+}
+
+//出品ボタン部分のクラス名は「.MenuPurchaseBtn」とする（内容はtopページ出品ボタンと同じ）
+.LogoutPurchaseBtn {
+  //「.MenuPurchaseBtn」以下のクラスは、部分テンプレートのscssにて指定
+}
+
+

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -6,4 +6,7 @@ class MypagesController < ApplicationController
   def creditcard
   end
 
+  def logout
+  end
+
 end

--- a/app/views/mypages/index.html.haml
+++ b/app/views/mypages/index.html.haml
@@ -140,7 +140,7 @@
                 電話番号の確認
                 %i.icon-arrow-right
             %li
-              = link_to "#", class: "MypageNavListItem" do
+              = link_to "http://localhost:3000/mypages/logout.html", class: "MypageNavListItem" do
                 ログアウト
                 %i.icon-arrow-right
 

--- a/app/views/mypages/logout.html.haml
+++ b/app/views/mypages/logout.html.haml
@@ -1,0 +1,33 @@
+-#ユーザーログアウト画面
+
+!!!
+
+.Single-Container
+
+  %header.LogoutHeader
+
+    -#Header部分（部分テンプレートで参照）
+    = render partial: "/layouts/main-header"
+
+
+  -#コンテンツ部分
+  %main.L-Container.clearfix
+
+    -#右側コンテンツ部分（ここでは「ログアウト」ボタン）
+    .L-Content
+      .L-Chapter-Container
+        %form#logout-form.L-Single-Inner{action: "#", method: "POST", novalidate: "novalidate"}
+          .L-Single-Content
+            %button.Btn-Default.btn-red{type: "submit"} ログアウト
+            %input{name: "__csrf_value", type: "hidden"}/
+
+
+  %footer.LogoutFooter
+    -#Banner部分+Footer部分（部分テンプレートで参照）
+    = render partial: "/layouts/main-footer"
+
+  .LogoutPurchaseBtn
+    -#右下の「出品する」ボタン（部分テンプレートで参照）
+    = render partial: "/layouts/purchasebtn"
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
     collection do
       get 'index'
       get 'creditcard'
+      get 'logout'
     end
   end
 


### PR DESCRIPTION
# What
フリマアプリのユーザーログアウト画面のマークアップ。
ユーザーマイページメニューの1つとするため、マイページからの遷移も併せて設定する。

# Why
開発するフリマアプリにて必要となるビューの実装。
ユーザーマイページに設定した、ユーザーログアウトメニューに相対する画面を作成するもの。

# ブラウザ表示画像
https://gyazo.com/295defde864df875cfdee02784529c66
