### PR TITLE
支払い方法選択画面の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,3 +10,4 @@
 @import "modules/mypage";
 @import "modules/creditcard";
 @import "modules/log-out";
+@import "modules/payment";

--- a/app/assets/stylesheets/modules/_payment.scss
+++ b/app/assets/stylesheets/modules/_payment.scss
@@ -1,0 +1,146 @@
+// Place all the styles related to the users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/
+
+
+* {
+  box-sizing: border-box;
+}
+
+//支払い方法選択画面（=mypages/payment.html）の装飾
+
+.Payment {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background-color: rgb(245, 245, 245);
+
+  .Payment-Main {
+    background-color: rgb(255, 255, 255);
+    max-width: 700px;
+    margin: 0px auto;
+    width: 100%;
+
+    .Payment-Primary {
+      position: relative;
+
+      .Payment-Section {
+        padding: 32px 16px;
+        border-bottom: 1px solid rgb(245, 245, 245);
+
+        .Payment-Title {
+          display: block;
+          text-align: center;
+          font-size: 24px;
+          line-height: 34px;
+          font-weight: 600;
+          margin: 0;
+          padding: 0;
+        }
+      }
+      .Payment-Secondary {
+        max-width: 375px;
+        margin: 0px auto;
+        padding: 0px 16px;
+
+        .Payment-Common {
+          padding: 32px 0px;
+          opacity: 1;
+          pointer-events: auto;
+          display: block;
+          border-top: 1px solid rgb(245, 245, 245);
+
+          .Radio-Btn {
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+
+            &__Block {
+              align-items: flex-start;
+              cursor: pointer;
+              display: inline-flex;
+              font-size: 14px;
+              line-height: 20px;
+
+              &__Checkbox {
+                display: inline-block;
+                flex: 0 0 auto;
+                height: 20px;
+                position: relative;
+                width: 20px;
+
+                input {
+                  border-radius: 50%;
+                  transition-duration: .1s;
+                  appearance: none;
+                  background-color: #fff;
+                  border: 1px solid #ccc;
+                  height: 100%;
+                  margin: 0;
+                  position: absolute;
+                  width: 100%;
+                  font-size: 100%;
+                }
+              }
+            }
+
+            &__Text {
+              margin: 0px 16px;
+
+              &__Section {
+                &__A {
+                  font-size: 14px;
+                  line-height: 1.4em;
+                }
+
+                &__B {
+                  font-size: 12px;
+                  margin: 4px 0px 0px;
+                  line-height: 1.7;
+                }
+              }
+            }
+          }
+
+          // .CreditCard {
+          .Cards {
+            list-style: none;
+          }
+
+          .CreditCard-Zone {
+            color: #0095ee;
+            margin: 0px;
+            align-items: center;
+            display: flex;
+            text-decoration: none;
+          }
+
+          .Btn {
+            background-color: #ccc;
+            color: #888;
+            width: 100%;
+            font-size: 17px;
+            min-height: 48px;
+            padding: 0 24px;
+            font-weight: 600;
+            line-height: 1;
+            overflow: hidden;
+            text-align: center;
+            text-decoration: none; 
+          }
+
+          .Btn-Text {
+            color: #0095ee;
+            margin-top: 32px;
+            text-align: center;
+            display: block;
+            text-decoration: none;
+            padding-bottom: 48px;
+          }
+        }
+      }
+    }
+  }
+}
+
+

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -9,4 +9,7 @@ class MypagesController < ApplicationController
   def logout
   end
 
+  def payment
+  end
+
 end

--- a/app/views/mypages/index.html.haml
+++ b/app/views/mypages/index.html.haml
@@ -124,7 +124,7 @@
                 発送元・お届け先住所変更
                 %i.icon-arrow-right
             %li
-              = link_to "#", class: "MypageNavListItem" do
+              = link_to "http://localhost:3000/mypages/payment", class: "MypageNavListItem" do
                 支払い方法
                 %i.icon-arrow-right
             %li

--- a/app/views/mypages/payment.html.haml
+++ b/app/views/mypages/payment.html.haml
@@ -1,0 +1,36 @@
+-#支払い方法選択画面
+
+.Payment
+  = render '/layouts/main-header'
+
+  .Payment-Main
+    .Payment-Primary
+      %section.Payment-Section
+        %h2.Payment-Title 支払い方法
+      .Payment-Secondary
+        %section.Payment-Common
+          .Radio-Btn
+            %span.Radio-Btn__Block{"data-test": "select-cvs-atm-checkbox"}
+              %span.Radio-Btn__Block__Checkbox
+                %input{type: "radio", value: "cvs_atm"}/
+                %svg{"aria-hidden": "true", fill: "#ffffff", "fill-rule": "evenodd", height: "16", viewbox: "0 0 24 24", width: "16"}
+                  %path{d: "M9.21,18.09a1.52,1.52,0,0,1-1.09-.44l-5-5a.71.71,0,0,1,0-1,.69.69,0,0,1,1,0l5,5a.26.26,0,0,0,.33-.07L19.92,6.11a.7.7,0,0,1,1,1L10.43,17.58A1.72,1.72,0,0,1,9.21,18.09Z"}
+            .Radio-Btn__Text
+              .Radio-Btn__Text__Section{"data-test": "cvs-atm-text-box"}
+                %p.Radio-Btn__Text__Section__A{"data-test": "cvs-atm-text"} コンビニ/ATM払い
+                %p.Radio-Btn__Text__Section__B{"data-test": "cvs-atm-fee-text"} (手数料¥100)
+        %section.Payment-Common
+          -# %ul.CreditCard
+          %ul.Cards
+          =link_to "+クレジットカードを追加", "http://localhost:3000/mypages/creditcard", class: "CreditCard-Zone"
+        %section.Payment-Common
+          %button.Btn{"data-test": "use-selected-payment-method", disabled: "disabled", tabindex: "-1", type: "button"} 選択した支払い方法を使う
+          =link_to "もどる", "http://localhost:3000/mypages/index.html", class: "Btn-Text"
+
+-#バナー+フッター
+= render '/layouts/main-footer'
+
+-#「出品する」ボタン
+= render '/layouts/purchasebtn'
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
       get 'index'
       get 'creditcard'
       get 'logout'
+      get 'payment'
     end
   end
 


### PR DESCRIPTION
# What
フリマアプリにおける代金支払い方法を選択する画面のマークアップ。
ユーザーマイページメニューの1つとするため、マイページからの遷移、
また、クレジットカード情報の再登録機能をつけるため、クレジットカード登録画面への遷移も併せて設定する。

# Why
開発するフリマアプリにて必要となるビューの実装。
ユーザーマイページに設定した、支払い方法選択メニューに相対する画面を作成するもの。

# ブラウザ表示画像
https://gyazo.com/afa042a11a158f7366b927ac7d83e942
