### PR TITLE
ユーザー登録機能の制約設定変更

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -19,6 +19,7 @@ class Address < ApplicationRecord
   validates :house_number, presence: true
   # validates :tel,
   # format: { with: /\A\d{10}\z/, message: "半角数字のみが使用できます"}
+  validates :tel, numericality: { allow_blank: true, message: "半角数字のみが使用できます"}
 
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :prefecture

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -96,7 +96,7 @@
         .Form-Group
           = f.label "address2_label", "電話"
           %span.Form-Arbitrary 任意
-          = f.number_field "tel", placeholder: "例) 1234567890", class: "Input-Default", value: ""
+          = f.text_field "tel", placeholder: "例) 1234567890", class: "Input-Default", value: ""
         = f.submit "登録する", class: "Btn-Default Btn-Red"
 
 %footer.Single-Footer

--- a/spec/models/adress_spec.rb
+++ b/spec/models/adress_spec.rb
@@ -55,12 +55,13 @@ describe Address do
       address.valid?
       expect(address.errors[:house_number]).to include("を入力してください")
     end
-    
-    it "telが半角数字でなければ登録できないこと" do
-      address = build(:address, tel: "０００００００００００") 
-      address.valid?
-      expect(address.errors[:tel]).to include("半角数字のみが使用できます")
-    end
+
+    #L96〜のケースと内容重複
+    # it "telが半角数字でなければ登録できないこと" do
+    #   address = build(:address, tel: "０００００００００００") 
+    #   address.valid?
+    #   expect(address.errors[:tel]).to include("半角数字のみが使用できます")
+    # end
 
     it "destination_family_nameが全角入力でなければ登録できないこと" do
       address = build(:address, destination_family_name: "ｱｲｳｴｵ") 
@@ -68,7 +69,7 @@ describe Address do
       expect(address.errors[:destination_family_name]).to include("全角ひらがな、全角カタカナ、漢字のみが使用できます")
     end
 
-    it "destination_family_nameが全角入力でなければ登録できないこと" do
+    it "destination_first_nameが全角入力でなければ登録できないこと" do
       address = build(:address, destination_first_name: "ｱｲｳｴｵ") 
       address.valid?
       expect(address.errors[:destination_first_name]).to include("全角ひらがな、全角カタカナ、漢字のみが使用できます")
@@ -96,6 +97,18 @@ describe Address do
       address = build(:address, tel: "０１０００００００００")
       address.valid?
       expect(address.errors[:tel]).to include("半角数字のみが使用できます")
+    end
+
+    #追加
+    it "telは空でも登録できる" do
+      address = build(:address, tel: "")
+      expect(address).to be_valid
+    end
+
+    #追加
+    it "buildingは空でも登録できる" do
+      address = build(:address, building: "")
+      expect(address).to be_valid
     end
 
   end


### PR DESCRIPTION
# What
ユーザー登録機能における、TEL番号の制約設定の変更。
コードレビューはチーム内のみとするが、経緯および作業記録の保存のため、branchを設けた。

# Why
ユーザー登録機能にて、TEL番号を任意入力とするところが必須入力の仕様になっていた。
（機能実装履歴：https://github.com/sd0821/flea-market-app/pull/10）
制約訂正のため、入力文字制約（半角数字のみ）の設定を解除し、任意入力の仕様を確保できたが、
入力文字制約を解除したことにより、当該機能の単体テストがfailureとなる影響が生じた。

双方の問題解決のため、任意入力かつ入力文字を制限する設定を再度追加するもの。

# 単体テスト実行結果画像
![単体テスト結果](https://user-images.githubusercontent.com/68807556/100420047-0e375880-30c9-11eb-8448-9eda214660ea.png)