### PR TITLE
商品購入機能の単体テスト

### DIFF
--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -2,6 +2,11 @@ class Card < ApplicationRecord
 
   belongs_to :user    #クレカ情報はuser_idのみへの連携
 
+  #機能テストにて必要と確認した制約を追加
+  validates :user_id,        presence: true
+  validates :customer_id,    presence: true
+  validates :payjp_id,       presence: true
+
 end
 
 

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -3,7 +3,7 @@ class Card < ApplicationRecord
   belongs_to :user    #クレカ情報はuser_idのみへの連携
 
   #機能テストにて必要と確認した制約を追加
-  validates :user_id,        presence: true
+  # validates :user_id,        presence: true    #「belongs_to :user」で必須入力は効いているので不要
   validates :customer_id,    presence: true
   validates :payjp_id,       presence: true
 

--- a/spec/factories/cards.rb
+++ b/spec/factories/cards.rb
@@ -1,0 +1,13 @@
+#クレカ登録機能のモデル単体テストデータ
+
+FactoryBot.define do
+  factory :card do
+
+    user_id        {1}
+    customer_id    {2}
+    payjp_id       {3}
+
+  end
+end
+
+

--- a/spec/factories/purchases.rb
+++ b/spec/factories/purchases.rb
@@ -1,0 +1,17 @@
+#商品購入機能のモデル単体テストデータ
+
+FactoryBot.define do
+
+  factory :purchase do
+
+    item_id    {1}    #出品商品のID
+    user_id    {1}    #購入者のuser_id
+
+    association :user
+    association :item
+
+  end
+
+end
+
+

--- a/spec/models/card_spec.rb
+++ b/spec/models/card_spec.rb
@@ -1,0 +1,37 @@
+#クレカ登録機能のモデル単体テストコード
+
+require 'rails_helper'
+
+describe Card do
+
+  describe '#pay（create）' do
+
+    it "必要なクレジットカード情報がすべて入力されれば登録できる" do
+      user = create(:user)
+      card = FactoryBot.build(:card, user_id: user[:id])
+      expect(card).to be_valid
+    end
+   
+    it "user_idがない場合は登録できない" do
+      card = build(:card, user_id: nil)
+      card.valid?
+      expect(card.errors[:user]).to include("を入力してください")
+    end
+    
+    it "customer_idがない場合は登録できない" do
+      card = build(:card, customer_id: nil)
+      card.valid?
+      expect(card.errors[:customer_id]).to include("を入力してください")
+    end
+    
+    it "payjp_idがない場合は登録できない" do
+      card = build(:card, payjp_id: nil)
+      card.valid?
+      expect(card.errors[:payjp_id]).to include("を入力してください")
+    end
+
+  end
+
+end
+
+

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -1,0 +1,34 @@
+#商品購入機能のモデル単体テストコード
+
+require 'rails_helper'
+
+describe Purchase do
+
+  describe '#create' do
+
+    it '必要情報がすべてあれば登録（購入）できる' do
+      user = create(:user)
+      purchase = build(:purchase, user_id: user.id)
+      purchase.valid?
+      expect(purchase).to be_valid
+    end
+
+    it 'item_idがない場合は登録（購入）できない' do
+      user = create(:user)
+      purchase = build(:purchase, user_id: user.id, item_id: nil)
+      purchase.valid?
+      expect(purchase.errors[:item_id]).to include("を入力してください")
+    end
+
+    it 'user_id（購入者情報）がない場合は登録（購入）できない' do
+      user = create(:user)
+      purchase = build(:purchase, user_id: nil)
+      purchase.valid?
+      expect(purchase.errors[:user_id]).to include("を入力してください")
+    end
+
+  end
+
+end
+
+


### PR DESCRIPTION
# What
商品購入に関するモデルの機能テスト。
クレジットカード登録機能、および商品購入機能のモデルテストコードを記述し、単体テストを実施。
（クレジットカード登録機能のMVC名：「card」、商品購入機能のMVC名：「purchase」）

# Why
フリマアプリの作成にあたり、クレジットカード登録操作および商品購入操作が正常に稼働することの確認が必要であるため。

# 単体テスト実行結果画像
![スクリーンショット 2020-12-11 2 00 59](https://user-images.githubusercontent.com/68807556/101804354-d6162800-3b54-11eb-8c1a-2e649d65510a.png)
