### PR TITLE
商品詳細画面の条件分岐設定変更

### DIFF
--- a/app/models/deliveryday.rb
+++ b/app/models/deliveryday.rb
@@ -1,6 +1,6 @@
 class Deliveryday < ActiveHash::Base
   self.data = [
-      {id: 1, name: '1~2日で発送'}, {id: 2, name: '2~3日で発送）'},{id: 3, name: '4~7日で発送'}
+      {id: 1, name: '1~2日で発送'}, {id: 2, name: '2~3日で発送'},{id: 3, name: '4~7日で発送'}
   ]
 
   include ActiveHash::Associations

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -70,19 +70,25 @@
               %li#Like-Btn.Optional-Btn.Like-Btn
                 %i.fa.fa-star
                 お気に入り 10
-          -if @purchase.present?
-            %a.item-buy-btn.soldout-btn
-              売り切れました  
-            = link_to item_path(@items), method: :delete, class: "item-buy-btn" do
-              削除 
-          -elsif user_signed_in? && current_user.id == @items.user_id
-            = link_to edit_item_path(@items), class: "item-buy-btn" do
-              編集
-            = link_to item_path(@items), method: :delete, class: "item-buy-btn" do
-              削除  
-          - else
-            = link_to new_item_purchase_path(@items), class: "item-buy-btn" do
-              購入画面に進む
+          -if @purchase.present?    #当該itemが購入済みの場合
+            -if user_signed_in? && current_user.id == @items.user_id    #閲覧者がログイン中の出品者本人の場合
+              %a.item-buy-btn.soldout-btn
+                売り切れました  
+              = link_to item_path(@items), method: :delete, class: "item-buy-btn" do
+                削除 
+            -else    #閲覧者が出品者本人でない場合、あるいはログアウト状態の場合
+              %a.item-buy-btn.soldout-btn
+                売り切れました  
+          - else    #当該itemがまだ販売中の場合
+            -if user_signed_in? && current_user.id == @items.user_id    #閲覧者がログイン中の出品者本人の場合
+              = link_to edit_item_path(@items), class: "item-buy-btn" do
+                編集
+              = link_to item_path(@items), method: :delete, class: "item-buy-btn" do
+                削除  
+            - else    #閲覧者が出品者本人でない場合、あるいはログアウト状態の場合
+              = link_to new_item_purchase_path(@items), class: "item-buy-btn" do
+                購入画面に進む
+
             %ul
             .Optional
               %li.Optional-Btn


### PR DESCRIPTION
# What
商品詳細画面における、操作ボタン表示の条件分岐設定の変更。
コードレビューはチーム内のみとするが、経緯および作業記録の保存のため、branchを設けた。

# Why
商品詳細画面にて、出品物が販売中か購入済みか、および閲覧者が出品者本人かどうかで条件を分け、
以降の画面に遷移するボタンの表示を変える設定を施した。
（機能実装履歴：https://github.com/sd0821/flea-market-app/pull/25）

出品itemの削除ボタンは、出品者本人の閲覧時のみ表示させる仕様を考えていたが、
出品者本人でないアカウントでの閲覧時にも削除ボタンが表示される設定になっていた。

この問題解決のため、条件分岐を見直してコードを修正変更するもの。